### PR TITLE
Clone using https in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 cmdln>=1.0
--e git+http://github.com/dotcloud/docker-py.git#egg=docker-py
+-e git+https://github.com/dotcloud/docker-py.git#egg=docker-py


### PR DESCRIPTION
When running the install script I encountered the following: `error: RPC failed; result=22, HTTP code = 405`
Switching to https resolves the issue and is also better for security purposes.

Details: 
- CentOS 6.4 (Vagrant VM)
- git 1.7.1
- pip 1.3.1
- python 2.6.6
